### PR TITLE
chore(commitlint): make body max line length infinity

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,9 @@ import type { UserConfig } from "@commitlint/types";
 
 const config: UserConfig = {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0, "always", Infinity],
+  },
 };
 
 export default config;


### PR DESCRIPTION
title

@coderabbitai ignore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated commit message validation rules to allow unlimited line length for message bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->