### PR TITLE
fix(renovate): ignore `next` in update PRs cuz were using canary

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "ignoreDeps": ["next"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration for dependency management to ignore specific dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->