### PR TITLE
fix(arrow-title): duplicate `ArrowTitle` component for animations to trigger

### DIFF
--- a/src/components/arrow-title.tsx
+++ b/src/components/arrow-title.tsx
@@ -67,10 +67,19 @@ export function ExperienceTitle({ className }: { className?: string }) {
         delay: 0.8,
       }}
     >
-      <ArrowTitle
-        text={guiMode ? "My Experience" : "Explore me through the terminal"}
-        slideDirection="bottom"
-      />
+      {guiMode ? (
+        <ArrowTitle
+          text="My Experience"
+          slideDirection="bottom"
+          key="experience"
+        />
+      ) : (
+        <ArrowTitle
+          text="Explore me through the terminal"
+          slideDirection="top"
+          key="terminal"
+        />
+      )}
     </RevealOnScroll>
   );
 }


### PR DESCRIPTION
- **Bug fixes**
	- Switched to using 2 _separate (with different keys)_ `ArrowTitle` components to trigger animation when switching from and to `guiMode`